### PR TITLE
provided callbackURL support

### DIFF
--- a/lib/passport-google-authcode/strategy.js
+++ b/lib/passport-google-authcode/strategy.js
@@ -16,7 +16,7 @@ var util = require('util')
  * `refreshToken` and service-specific `profile`, and then calls the `done`
  * callback supplying a `user`, which should be set to `false` if the
  * credentials are not valid.  If an exception occured, `err` should be set.
- * 
+ *
  * Options:
  *   - `clientID`      your Google application's client id
  *   - `clientSecret`  your Google application's client secret
@@ -44,7 +44,7 @@ function GoogleAuthCodeStrategy(options, verify) {
   options.tokenURL = options.tokenURL || 'https://accounts.google.com/o/oauth2/token';
 
   this._passReqToCallback = options.passReqToCallback;
-  
+
   OAuth2Strategy.call(this, options, verify);
   this.name = 'google-authcode';
 }
@@ -70,29 +70,29 @@ GoogleAuthCodeStrategy.prototype.authenticate = function(req, options) {
     //       query parameters, and should be propagated to the application.
     return this.fail();
   }
-  
+
   if (!req.body) {
     return this.fail();
   }
-  
+
   var authCode = req.body.code || req.query.code;
-  
+
   if (!authCode) {
 	  return this.fail();
   }
-  
+
   self._exchangeAuthCode(authCode, function(err, accessToken, refreshToken, resultsJson) {
     if (err) { return self.fail(err); };
 
     self._loadUserProfile(accessToken, function(err, profile) {
       if (err) { return self.fail(err); };
-      
+
       function verified(err, user, info) {
         if (err) { return self.error(err); }
         if (!user) { return self.fail(info); }
         self.success(user, info);
       }
-      
+
       if (self._passReqToCallback) {
         self._verify(req, accessToken, refreshToken, profile, verified);
       } else {
@@ -113,6 +113,9 @@ GoogleAuthCodeStrategy.prototype._exchangeAuthCode = function(authCode, done) {
   var params = {
     'grant_type': 'authorization_code',
   };
+  if (this._callbackURL) {
+    params.redirect_uri = this._callbackURL;
+  }
   this._oauth2.getOAuthAccessToken(authCode, params, done);
 }
 
@@ -134,20 +137,20 @@ GoogleAuthCodeStrategy.prototype._exchangeAuthCode = function(authCode, done) {
 GoogleAuthCodeStrategy.prototype.userProfile = function(accessToken, done) {
   this._oauth2.get('https://www.googleapis.com/oauth2/v1/userinfo', accessToken, function (err, body, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
-    
+
     try {
       var json = JSON.parse(body);
-      
+
       var profile = { provider: 'google' };
       profile.id = json.id;
       profile.displayName = json.name;
       profile.name = { familyName: json.family_name,
                        givenName: json.given_name };
       profile.emails = [{ value: json.email }];
-      
+
       profile._raw = body;
       profile._json = json;
-      
+
       done(null, profile);
     } catch(e) {
       done(e);
@@ -190,5 +193,5 @@ GoogleAuthCodeStrategy.prototype._loadUserProfile = function(accessToken, done) 
 
 /**
  * Expose `GoogleAuthCodeStrategy`.
- */ 
+ */
 module.exports = GoogleAuthCodeStrategy;


### PR DESCRIPTION
Google Oauth2 `authorication_code` grant flow usually does not require `redirect_uri` to be set.

However, when granting offline access using Google+ Sign-In server-side flow it is **obligatory** to have the `redirect_uri` query parameter to be set to `"postmessage"` string. This is especially useful for implementing Google Contextual gadgets that are running in a separate iframe.

This pull request allows users to pass any string to callbackURL parameter.

Here is example working code:

```javascript
passport.use('gadget-authcode', new GoogleAuthCodeStrategy({
        clientID: config.auth.gmailGadget.id,
        clientSecret: config.auth.gmailGadget.secret,
        callbackURL: 'postmessage',
        passReqToCallback: true
    },
    googleAuth
));
```

Thanks for reviewing this pull request. Should you require any other information don't hesitate to ask me back.