### PR TITLE
update googleapis version

### DIFF
--- a/lib/passport-google-authcode/strategy.js
+++ b/lib/passport-google-authcode/strategy.js
@@ -71,7 +71,7 @@ GoogleAuthCodeStrategy.prototype.authenticate = function(req, options) {
     return this.fail();
   }
   
-  if (!req.body || !req.query || !req.headers) {
+  if (!req.body && !req.query && !req.headers) {
     return this.fail();
   }
   

--- a/lib/passport-google-authcode/strategy.js
+++ b/lib/passport-google-authcode/strategy.js
@@ -71,7 +71,7 @@ GoogleAuthCodeStrategy.prototype.authenticate = function(req, options) {
     return this.fail();
   }
   
-  if (!req.body) {
+  if (!req.body || !req.query || !req.headers) {
     return this.fail();
   }
   
@@ -133,7 +133,7 @@ GoogleAuthCodeStrategy.prototype._exchangeAuthCode = function(authCode, done) {
  * @api protected
  */
 GoogleAuthCodeStrategy.prototype.userProfile = function(accessToken, done) {
-  this._oauth2.get('https://www.googleapis.com/oauth2/v1/userinfo', accessToken, function (err, body, res) {
+  this._oauth2.get('https://www.googleapis.com/oauth2/v3/userinfo', accessToken, function (err, body, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
     
     try {


### PR DESCRIPTION
This is related to my previous commit, if I understand well, the line 74 raise an error if the user don't pass the code in the body of the request.
We should also allow the user to pass the code in the headers or as request parameter.
Also I think it's better to use the last api version but this has to be tested.
