### PR TITLE
Set redirect_uri option to "postmessage"

### DIFF
--- a/lib/passport-google-authcode/strategy.js
+++ b/lib/passport-google-authcode/strategy.js
@@ -119,7 +119,7 @@ GoogleAuthCodeStrategy.prototype.authenticate = function(req, options) {
 GoogleAuthCodeStrategy.prototype._exchangeAuthCode = function(authCode, done) {
   var params = {
     'grant_type': 'authorization_code',
-    'redirect_uri': this._callbackURL
+    'redirect_uri': 'postmessage'
   };
   this._oauth2.getOAuthAccessToken(authCode, params, done);
 }


### PR DESCRIPTION
- fix for "missing param redirect_uri" error response

#9 